### PR TITLE
change: remove unused field SnapshotMeta::membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
 ---
 
 
-## From datafuse developer:
+## From databend developer:
 
 **This fork fixed several bugs in the original async-raft, introduced new features
 and is matinained by datafuse team. The API and internal data structure has changed
-to fit the latest [datafuse](https://github.com/datafuselabs/datafuse) need.**
+to fit the latest [databend](https://github.com/datafuselabs/databend) need.**
 
 The tags in form of `v0.6.2-alpha.*` are datafuse maintained versions.
 They are well tested but it should still be considered as a beta.

--- a/async-raft/src/core/admin.rs
+++ b/async-raft/src/core/admin.rs
@@ -121,7 +121,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
 
         // The last membership config is not committed yet.
         // Can not process the next one.
-        if self.core.commit_index < self.core.effective_membership.log_id.index {
+        if self.core.committed < self.core.effective_membership.log_id {
             let _ = tx.send(Err(ClientWriteError::ChangeMembershipError(
                 ChangeMembershipError::InProgress {
                     membership_log_id: self.core.effective_membership.log_id,

--- a/async-raft/src/core/client.rs
+++ b/async-raft/src/core/client.rs
@@ -73,6 +73,7 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
             entry: Arc::new(entry),
             tx: None,
         };
+        // TODO(xp): it should update the lost_log_id
         self.replicate_client_request(cr_entry).await;
 
         Ok(())

--- a/async-raft/src/core/install_snapshot.rs
+++ b/async-raft/src/core/install_snapshot.rs
@@ -204,7 +204,6 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             .map_err(|e| self.map_storage_error(e))?;
 
         tracing::debug!("update after apply or install-snapshot: {:?}", changes);
-        println!("update after apply or install-snapshot: {:?}", changes);
 
         // After installing snapshot, no inconsistent log is removed.
         // This does not affect raft consistency.
@@ -219,8 +218,8 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
             // snapshot is installed
             self.last_applied = last_applied;
 
-            if self.commit_index < self.last_applied.index {
-                self.commit_index = self.last_applied.index;
+            if self.committed < self.last_applied {
+                self.committed = self.last_applied;
             }
             if self.last_log_id < self.last_applied {
                 self.last_log_id = self.last_applied;
@@ -228,7 +227,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Ra
 
             // There could be unknown membership in the snapshot.
             let membership = self.storage.get_membership_config().await.map_err(|err| self.map_storage_error(err))?;
-            println!("storage membership: {:?}", membership);
+            tracing::debug!("storage membership: {:?}", membership);
 
             self.update_membership(membership)?;
 

--- a/async-raft/src/core/mod.rs
+++ b/async-raft/src/core/mod.rs
@@ -714,7 +714,6 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
         self.core.update_current_leader(UpdateCurrentLeader::ThisNode);
         self.leader_report_metrics();
 
-        // Per §8, commit an initial entry as part of becoming the cluster leader.
         self.commit_initial_leader_entry().await?;
 
         loop {

--- a/async-raft/src/core/vote.rs
+++ b/async-raft/src/core/vote.rs
@@ -157,26 +157,25 @@ impl<'a, D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>
     /// Spawn parallel vote requests to all cluster members.
     #[tracing::instrument(level = "trace", skip(self))]
     pub(super) fn spawn_parallel_vote_requests(&self) -> mpsc::Receiver<(VoteResponse, NodeId)> {
-        let all_members = self.core.effective_membership.membership.all_nodes().clone();
-        let (tx, rx) = mpsc::channel(all_members.len());
-        for member in all_members.into_iter().filter(|member| member != &self.core.id) {
-            let rpc = VoteRequest::new(
-                self.core.current_term,
-                self.core.id,
-                self.core.last_log_id.index,
-                self.core.last_log_id.term,
-            );
+        let all_nodes = self.core.effective_membership.membership.all_nodes().clone();
+        let (tx, rx) = mpsc::channel(all_nodes.len());
+
+        for member in all_nodes.into_iter().filter(|member| member != &self.core.id) {
+            let rpc = VoteRequest::new(self.core.current_term, self.core.id, self.core.last_log_id);
+
             let (network, tx_inner) = (self.core.network.clone(), tx.clone());
             let _ = tokio::spawn(
                 async move {
-                    match network.send_vote(member, rpc).await {
-                        Ok(res) => {
-                            let _ = tx_inner.send((res, member)).await;
+                    let res = network.send_vote(member, rpc).await;
+
+                    match res {
+                        Ok(vote_resp) => {
+                            let _ = tx_inner.send((vote_resp, member)).await;
                         }
-                        Err(err) => tracing::error!({error=%err, peer=member}, "error while requesting vote from peer"),
+                        Err(err) => tracing::error!({error=%err, target=member}, "while requesting vote"),
                     }
                 }
-                .instrument(tracing::debug_span!("requesting vote from peer", target = member)),
+                .instrument(tracing::debug_span!("send_vote_req", target = member)),
             );
         }
         rx

--- a/async-raft/src/error.rs
+++ b/async-raft/src/error.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 use std::fmt::Debug;
 use std::time::Duration;
 
-use crate::raft::MembershipConfig;
+use crate::raft::Membership;
 use crate::raft_types::SnapshotSegmentId;
 use crate::LogId;
 use crate::NodeId;
@@ -179,10 +179,7 @@ pub enum ChangeMembershipError {
     // TODO(xp): rename this error to some elaborated name.
     // TODO(xp): 111 test it
     #[error("now allowed to change from {curr:?} to {to:?}")]
-    Incompatible {
-        curr: MembershipConfig,
-        to: BTreeSet<NodeId>,
-    },
+    Incompatible { curr: Membership, to: BTreeSet<NodeId> },
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/async-raft/src/membership_test.rs
+++ b/async-raft/src/membership_test.rs
@@ -3,14 +3,14 @@ use std::collections::BTreeMap;
 use maplit::btreemap;
 use maplit::btreeset;
 
-use crate::raft::MembershipConfig;
+use crate::raft::Membership;
 use crate::NodeId;
 
 #[test]
 fn test_membership() -> anyhow::Result<()> {
-    let m1 = MembershipConfig::new_multi(vec![btreeset! {1}]);
-    let m123 = MembershipConfig::new_multi(vec![btreeset! {1,2,3}]);
-    let m123_345 = MembershipConfig::new_multi(vec![btreeset! {1,2,3}, btreeset! {3,4,5}]);
+    let m1 = Membership::new_multi(vec![btreeset! {1}]);
+    let m123 = Membership::new_multi(vec![btreeset! {1,2,3}]);
+    let m123_345 = Membership::new_multi(vec![btreeset! {1,2,3}, btreeset! {3,4,5}]);
 
     assert_eq!(Some(btreeset! {1}), m1.get_ith_config(0).cloned());
     assert_eq!(Some(btreeset! {1,2,3}), m123.get_ith_config(0).cloned());
@@ -37,10 +37,7 @@ fn test_membership() -> anyhow::Result<()> {
     assert!(!m123.is_in_joint_consensus());
     assert!(m123_345.is_in_joint_consensus());
 
-    assert_eq!(
-        MembershipConfig::new_single(btreeset! {3,4,5}),
-        m123_345.to_final_config()
-    );
+    assert_eq!(Membership::new_single(btreeset! {3,4,5}), m123_345.to_final_config());
 
     Ok(())
 }
@@ -49,7 +46,7 @@ fn test_membership() -> anyhow::Result<()> {
 fn test_membership_update() -> anyhow::Result<()> {
     // --- replace
 
-    let mut m123 = MembershipConfig::new_single(btreeset! {1,2,3});
+    let mut m123 = Membership::new_single(btreeset! {1,2,3});
     m123.replace(vec![btreeset! {2,3}, btreeset! {3,4}]);
 
     assert_eq!(&btreeset! {2,3,4}, m123.all_nodes());
@@ -78,7 +75,7 @@ fn test_membership_update() -> anyhow::Result<()> {
 #[test]
 fn test_membership_majority() -> anyhow::Result<()> {
     {
-        let m12345 = MembershipConfig::new_single(btreeset! {1,2,3,4,5});
+        let m12345 = Membership::new_single(btreeset! {1,2,3,4,5});
         assert!(!m12345.is_majority(&btreeset! {0}));
         assert!(!m12345.is_majority(&btreeset! {0,1,2}));
         assert!(!m12345.is_majority(&btreeset! {6,7,8}));
@@ -88,7 +85,7 @@ fn test_membership_majority() -> anyhow::Result<()> {
     }
 
     {
-        let m12345_678 = MembershipConfig::new_multi(vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}]);
+        let m12345_678 = Membership::new_multi(vec![btreeset! {1,2,3,4,5}, btreeset! {6,7,8}]);
         assert!(!m12345_678.is_majority(&btreeset! {0}));
         assert!(!m12345_678.is_majority(&btreeset! {0,1,2}));
         assert!(!m12345_678.is_majority(&btreeset! {6,7,8}));
@@ -103,7 +100,7 @@ fn test_membership_majority() -> anyhow::Result<()> {
 #[test]
 fn test_membership_greatest_majority_value() -> anyhow::Result<()> {
     {
-        let m123 = MembershipConfig::new_single(btreeset! {1,2,3});
+        let m123 = Membership::new_single(btreeset! {1,2,3});
         assert_eq!(None, m123.greatest_majority_value(&BTreeMap::<NodeId, u64>::new()));
         assert_eq!(None, m123.greatest_majority_value(&btreemap! {0=>10}));
         assert_eq!(None, m123.greatest_majority_value(&btreemap! {0=>10,1=>10}));
@@ -115,7 +112,7 @@ fn test_membership_greatest_majority_value() -> anyhow::Result<()> {
     }
 
     {
-        let m123_678 = MembershipConfig::new_multi(vec![btreeset! {1,2,3}, btreeset! {6,7,8}]);
+        let m123_678 = Membership::new_multi(vec![btreeset! {1,2,3}, btreeset! {6,7,8}]);
         assert_eq!(None, m123_678.greatest_majority_value(&btreemap! {0=>10}));
         assert_eq!(None, m123_678.greatest_majority_value(&btreemap! {0=>10,1=>10}));
         assert_eq!(None, m123_678.greatest_majority_value(&btreemap! {0=>10,1=>10,2=>20}));

--- a/async-raft/src/metrics.rs
+++ b/async-raft/src/metrics.rs
@@ -19,7 +19,7 @@ use tokio::time::Instant;
 
 use crate::core::EffectiveMembership;
 use crate::core::State;
-use crate::raft::MembershipConfig;
+use crate::raft::Membership;
 use crate::LogId;
 use crate::NodeId;
 use crate::RaftError;
@@ -60,7 +60,7 @@ pub struct LeaderMetrics {
 
 impl RaftMetrics {
     pub(crate) fn new_initial(id: NodeId) -> Self {
-        let membership_config = MembershipConfig::new_initial(id);
+        let membership_config = Membership::new_initial(id);
         Self {
             id,
             state: State::Follower,

--- a/async-raft/src/metrics_wait_test.rs
+++ b/async-raft/src/metrics_wait_test.rs
@@ -7,7 +7,7 @@ use tokio::time::sleep;
 use crate::core::EffectiveMembership;
 use crate::metrics::Wait;
 use crate::metrics::WaitError;
-use crate::raft::MembershipConfig;
+use crate::raft::Membership;
 use crate::LogId;
 use crate::RaftMetrics;
 use crate::State;
@@ -184,7 +184,7 @@ fn init_wait_test() -> (RaftMetrics, Wait, watch::Sender<RaftMetrics>) {
         current_leader: None,
         membership_config: EffectiveMembership {
             log_id: LogId::default(),
-            membership: MembershipConfig::new_single(btreeset! {}),
+            membership: Membership::new_single(btreeset! {}),
         },
 
         snapshot: LogId { term: 0, index: 0 },

--- a/async-raft/src/raft.rs
+++ b/async-raft/src/raft.rs
@@ -501,8 +501,8 @@ pub struct AppendEntriesRequest<D: AppData> {
     #[serde(bound = "D: AppData")]
     pub entries: Vec<Entry<D>>,
 
-    /// The leader's commit index.
-    pub leader_commit: u64,
+    /// The leader's committed log id.
+    pub leader_commit: LogId,
 }
 
 impl<D: AppData> MessageSummary for AppendEntriesRequest<D> {

--- a/async-raft/src/raft.rs
+++ b/async-raft/src/raft.rs
@@ -614,8 +614,61 @@ impl<D: AppData> MessageSummary for EntryPayload<D> {
 //////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// The membership configuration of the cluster.
-/// Unlike original raft, the membership always a joint.
-/// It could be a joint of one, two or more members, i.e., a quorum requires a majority of every members
+///
+/// It could be a joint of one, two or more members list, i.e., a quorum requires a majority of every members.
+///
+/// The structure of membership is actually a log:
+/// ```text
+/// 2-3: [6,7,8]
+/// 1-2: [3,4,5]
+/// 1-1: [1,2,3]
+/// ```
+///
+/// Without any limitation, a node uses the **joint** of every config
+/// as the effective quorum.
+///
+/// But **raft** tries to eliminate the items in a membership config to at most 2, e.g.:
+/// single item config is the normal majority quorum,
+/// double items config is the raft joint membership config.
+///
+/// To achieve this, raft has to guarantee that a 2-entries config contains all valid quorum:
+/// E.g.: given the current config of node p and q as the following:
+///
+/// Node p:
+/// ```text
+/// A-B: [a,b,c]
+/// 1-2: [3,4,5] <- commit_index
+/// 1-1: [1,2,3]
+/// ```
+///
+/// Node q:
+/// ```text
+/// X-Y: [x,y,z]
+/// 1-1: [1,2,3] <- commit_index
+/// ```
+///
+/// ```text
+/// A-B <- p
+///  |
+/// 1-2   X-Y <- q
+///  |  /
+/// 1-1
+/// ```
+///
+/// If we knows about which log entry is committed,
+/// the effective membership can be reduced to the joint of the last committed membership and all uncommitted
+/// memberships, because:
+///
+/// - Two nodes has equal greatest committed membership always include the last committed membership in the joint config
+///   so that they won't both become a leader.
+///
+/// - A node has smaller committed membership will see a higher log thus it won't be a new leader, such as q.
+///
+/// This way, to keep at most 2 member list in the membership config:
+///
+/// - raft does not allow two uncommitted membership in its log,
+/// - and stores the last committed membership and the newly proposed membership in on log entry(because raft does not
+///   store committed index), which is the joint membership entry.
 #[derive(Clone, Default, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Membership {
     /// Multi configs.
@@ -665,8 +718,6 @@ impl Membership {
     }
 
     /// Check if the given NodeId exists in this membership config.
-    ///
-    /// When in joint consensus, this will check both config groups.
     pub fn contains(&self, x: &NodeId) -> bool {
         for c in self.configs.iter() {
             if c.contains(x) {
@@ -768,7 +819,6 @@ pub struct VoteRequest {
     /// The candidate's current term.
     pub term: u64,
 
-    /// The candidate's ID.
     pub candidate_id: u64,
 
     pub last_log_id: LogId,
@@ -781,15 +831,11 @@ impl MessageSummary for VoteRequest {
 }
 
 impl VoteRequest {
-    /// Create a new instance.
-    pub fn new(term: u64, candidate_id: u64, last_log_index: u64, last_log_term: u64) -> Self {
+    pub fn new(term: u64, candidate_id: u64, last_log_id: LogId) -> Self {
         Self {
             term,
             candidate_id,
-            last_log_id: LogId {
-                term: last_log_term,
-                index: last_log_index,
-            },
+            last_log_id,
         }
     }
 }

--- a/async-raft/src/raft_types.rs
+++ b/async-raft/src/raft_types.rs
@@ -14,7 +14,7 @@ pub struct LogId {
 
 impl From<(u64, u64)> for LogId {
     fn from(v: (u64, u64)) -> Self {
-        LogId { term: v.0, index: v.1 }
+        LogId::new(v.0, v.1)
     }
 }
 
@@ -26,6 +26,10 @@ impl Display for LogId {
 
 impl LogId {
     pub fn new(term: u64, index: u64) -> Self {
+        if term == 0 || index == 0 {
+            assert_eq!(index, 0, "zero-th log entry must be (0,0), but {}, {}", term, index);
+            assert_eq!(term, 0, "zero-th log entry must be (0,0), but {}, {}", term, index);
+        }
         LogId { term, index }
     }
 }

--- a/async-raft/src/replication/mod.rs
+++ b/async-raft/src/replication/mod.rs
@@ -139,6 +139,7 @@ struct ReplicationCore<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: Raf
 
 impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> ReplicationCore<D, R, N, S> {
     /// Spawn a new replication task for the target node.
+    #[tracing::instrument(level = "debug", skip(config, network, storage, raft_core_tx))]
     pub(self) fn spawn(
         id: NodeId,
         target: NodeId,
@@ -383,6 +384,7 @@ impl<D: AppData, R: AppDataResponse, N: RaftNetwork<D>, S: RaftStorage<D, R>> Re
     }
 
     /// max_possible_matched_index is the least index for `prev_log_id` to form a consecutive log sequence
+    #[tracing::instrument(level = "debug", skip(self), fields(max_possible_matched_index=self.max_possible_matched_index))]
     fn check_consecutive(&self, first_log_index: u64) -> Result<(), ReplicationError> {
         if first_log_index > self.max_possible_matched_index {
             return Err(ReplicationError::LackEntry(LackEntry {

--- a/async-raft/src/storage.rs
+++ b/async-raft/src/storage.rs
@@ -26,9 +26,6 @@ pub struct SnapshotMeta {
     // Log entries upto which this snapshot includes, inclusive.
     pub last_log_id: LogId,
 
-    /// The latest membership configuration covered by the snapshot.
-    pub membership: Membership,
-
     /// To identify a snapshot when transferring.
     /// Caveat: even when two snapshot is built with the same `last_log_id`, they still could be different in bytes.
     pub snapshot_id: SnapshotId,

--- a/async-raft/src/storage.rs
+++ b/async-raft/src/storage.rs
@@ -12,7 +12,7 @@ use tokio::io::AsyncWrite;
 
 use crate::core::EffectiveMembership;
 use crate::raft::Entry;
-use crate::raft::MembershipConfig;
+use crate::raft::Membership;
 use crate::raft_types::SnapshotId;
 use crate::raft_types::StateMachineChanges;
 use crate::AppData;
@@ -27,7 +27,7 @@ pub struct SnapshotMeta {
     pub last_log_id: LogId,
 
     /// The latest membership configuration covered by the snapshot.
-    pub membership: MembershipConfig,
+    pub membership: Membership,
 
     /// To identify a snapshot when transferring.
     /// Caveat: even when two snapshot is built with the same `last_log_id`, they still could be different in bytes.
@@ -89,7 +89,7 @@ impl InitialState {
             },
             last_membership: EffectiveMembership {
                 log_id: LogId { term: 0, index: 0 },
-                membership: MembershipConfig::new_initial(id),
+                membership: Membership::new_initial(id),
             },
         }
     }

--- a/async-raft/src/store_ext.rs
+++ b/async-raft/src/store_ext.rs
@@ -8,6 +8,7 @@ use crate::raft::Entry;
 use crate::storage::HardState;
 use crate::storage::InitialState;
 use crate::storage::Snapshot;
+use crate::summary::MessageSummary;
 use crate::AppData;
 use crate::AppDataResponse;
 use crate::DefensiveCheck;
@@ -84,25 +85,30 @@ where
 {
     type SnapshotData = T::SnapshotData;
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_membership_config(&self) -> Result<EffectiveMembership, StorageError> {
         self.defensive_no_dirty_log().await?;
         self.inner().get_membership_config().await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_initial_state(&self) -> Result<InitialState, StorageError> {
         self.defensive_no_dirty_log().await?;
         self.inner().get_initial_state().await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn save_hard_state(&self, hs: &HardState) -> Result<(), StorageError> {
         self.defensive_incremental_hard_state(hs).await?;
         self.inner().save_hard_state(hs).await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn read_hard_state(&self) -> Result<Option<HardState>, StorageError> {
         self.inner().read_hard_state().await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_log_entries<RNG: RangeBounds<u64> + Clone + Debug + Send + Sync>(
         &self,
         range: RNG,
@@ -116,6 +122,7 @@ where
         Ok(res)
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn try_get_log_entries<RNG: RangeBounds<u64> + Clone + Debug + Send + Sync>(
         &self,
         range: RNG,
@@ -125,26 +132,32 @@ where
         self.inner().try_get_log_entries(range).await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn try_get_log_entry(&self, log_index: u64) -> Result<Option<Entry<D>>, StorageError> {
         self.inner().try_get_log_entry(log_index).await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn first_id_in_log(&self) -> Result<Option<LogId>, StorageError> {
         self.inner().first_id_in_log().await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn first_known_log_id(&self) -> Result<LogId, StorageError> {
         self.inner().first_known_log_id().await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn last_id_in_log(&self) -> Result<LogId, StorageError> {
         self.inner().last_id_in_log().await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn last_applied_state(&self) -> Result<(LogId, Option<EffectiveMembership>), StorageError> {
         self.inner().last_applied_state().await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn delete_logs_from<RNG: RangeBounds<u64> + Clone + Debug + Send + Sync>(
         &self,
         range: RNG,
@@ -155,6 +168,7 @@ where
         self.inner().delete_logs_from(range).await
     }
 
+    #[tracing::instrument(level = "debug", skip(self, entries), fields(entries=%entries.summary()))]
     async fn append_to_log(&self, entries: &[&Entry<D>]) -> Result<(), StorageError> {
         self.defensive_nonempty_input(entries).await?;
         self.defensive_consecutive_input(entries).await?;
@@ -164,6 +178,7 @@ where
         self.inner().append_to_log(entries).await
     }
 
+    #[tracing::instrument(level = "debug", skip(self, entries), fields(entries=%entries.summary()))]
     async fn apply_to_state_machine(&self, entries: &[&Entry<D>]) -> Result<Vec<R>, StorageError> {
         self.defensive_nonempty_input(entries).await?;
         self.defensive_apply_index_is_last_applied_plus_one(entries).await?;
@@ -172,14 +187,17 @@ where
         self.inner().apply_to_state_machine(entries).await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn do_log_compaction(&self) -> Result<Snapshot<Self::SnapshotData>, StorageError> {
         self.inner().do_log_compaction().await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn begin_receiving_snapshot(&self) -> Result<Box<Self::SnapshotData>, StorageError> {
         self.inner().begin_receiving_snapshot().await
     }
 
+    #[tracing::instrument(level = "debug", skip(self, snapshot))]
     async fn finalize_snapshot_installation(
         &self,
         meta: &SnapshotMeta,
@@ -188,6 +206,7 @@ where
         self.inner().finalize_snapshot_installation(meta, snapshot).await
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn get_current_snapshot(&self) -> Result<Option<Snapshot<Self::SnapshotData>>, StorageError> {
         self.inner().get_current_snapshot().await
     }

--- a/async-raft/tests/api_install_snapshot.rs
+++ b/async-raft/tests/api_install_snapshot.rs
@@ -52,7 +52,6 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
         meta: SnapshotMeta {
             snapshot_id: "ss1".into(),
             last_log_id: LogId { term: 1, index: 0 },
-            membership: Default::default(),
         },
         offset: 0,
         data: vec![1, 2, 3],

--- a/async-raft/tests/append_conflicts.rs
+++ b/async-raft/tests/append_conflicts.rs
@@ -209,8 +209,13 @@ where
     Sto: RaftStorage<D, R>,
 {
     let logs = sto.get_log_entries(..).await?;
-    let want: Vec<Entry<ClientRequest>> =
-        terms.iter().enumerate().map(|(i, term)| ent(*term, (i) as u64)).collect::<Vec<_>>();
+    let skip = 0;
+    let want: Vec<Entry<ClientRequest>> = terms
+        .iter()
+        .skip(skip)
+        .enumerate()
+        .map(|(i, term)| ent(*term, (i + skip) as u64))
+        .collect::<Vec<_>>();
 
     assert_eq!(want.as_slice().summary(), logs.as_slice().summary());
 

--- a/async-raft/tests/append_conflicts.rs
+++ b/async-raft/tests/append_conflicts.rs
@@ -51,7 +51,7 @@ async fn append_conflicts() -> Result<()> {
         leader_id: 0,
         prev_log_id: LogId::new(0, 0),
         entries: vec![],
-        leader_commit: 2,
+        leader_commit: LogId::new(1, 2),
     };
 
     let resp = r0.append_entries(req.clone()).await?;
@@ -68,7 +68,7 @@ async fn append_conflicts() -> Result<()> {
         prev_log_id: LogId::new(0, 0),
         entries: vec![ent(1, 1), ent(1, 2), ent(1, 3), ent(1, 4)],
         // this set the last_applied to 2
-        leader_commit: 2,
+        leader_commit: LogId::new(1, 2),
     };
 
     let resp = r0.append_entries(req.clone()).await?;
@@ -93,7 +93,7 @@ async fn append_conflicts() -> Result<()> {
         leader_id: 0,
         prev_log_id: LogId::new(1, 1),
         entries: vec![ent(1, 2)],
-        leader_commit: 2,
+        leader_commit: LogId::new(1, 2),
     };
 
     let resp = r0.append_entries(req).await?;
@@ -110,7 +110,7 @@ async fn append_conflicts() -> Result<()> {
         prev_log_id: LogId::new(1, 2),
         entries: vec![ent(2, 3)],
         // this set the last_applied to 2
-        leader_commit: 2,
+        leader_commit: LogId::new(1, 2),
     };
 
     let resp = r0.append_entries(req).await?;
@@ -125,7 +125,7 @@ async fn append_conflicts() -> Result<()> {
         leader_id: 0,
         prev_log_id: LogId::new(1, 2000),
         entries: vec![],
-        leader_commit: 2,
+        leader_commit: LogId::new(1, 2),
     };
 
     let resp = r0.append_entries(req).await?;
@@ -141,7 +141,7 @@ async fn append_conflicts() -> Result<()> {
         leader_id: 0,
         prev_log_id: LogId::new(3, 3),
         entries: vec![],
-        leader_commit: 2,
+        leader_commit: LogId::new(1, 2),
     };
 
     let resp = r0.append_entries(req).await?;
@@ -158,7 +158,7 @@ async fn append_conflicts() -> Result<()> {
         leader_id: 0,
         prev_log_id: LogId::new(1, 2),
         entries: vec![ent(2, 3), ent(2, 4), ent(2, 5)],
-        leader_commit: 2,
+        leader_commit: LogId::new(1, 2),
     };
 
     let resp = r0.append_entries(req).await?;
@@ -174,7 +174,7 @@ async fn append_conflicts() -> Result<()> {
         leader_id: 0,
         prev_log_id: LogId::new(2, 3),
         entries: vec![ent(3, 4)],
-        leader_commit: 2,
+        leader_commit: LogId::new(1, 2),
     };
 
     let resp = r0.append_entries(req).await?;
@@ -191,7 +191,7 @@ async fn append_conflicts() -> Result<()> {
         leader_id: 0,
         prev_log_id: LogId::new(1, 200),
         entries: vec![],
-        leader_commit: 2,
+        leader_commit: LogId::new(1, 2),
     };
 
     let resp = r0.append_entries(req).await?;

--- a/async-raft/tests/append_updates_membership.rs
+++ b/async-raft/tests/append_updates_membership.rs
@@ -61,7 +61,7 @@ async fn append_updates_membership() -> Result<()> {
                 },
                 ent(1, 5),
             ],
-            leader_commit: 0,
+            leader_commit: LogId::new(0, 0),
         };
 
         let resp = r0.append_entries(req.clone()).await?;
@@ -78,7 +78,7 @@ async fn append_updates_membership() -> Result<()> {
             leader_id: 0,
             prev_log_id: LogId::new(1, 2),
             entries: vec![ent(2, 3)],
-            leader_commit: 0,
+            leader_commit: LogId::new(0, 0),
         };
 
         let resp = r0.append_entries(req.clone()).await?;

--- a/async-raft/tests/append_updates_membership.rs
+++ b/async-raft/tests/append_updates_membership.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use async_raft::raft::AppendEntriesRequest;
 use async_raft::raft::Entry;
 use async_raft::raft::EntryPayload;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::AppData;
 use async_raft::Config;
 use async_raft::LogId;
@@ -52,12 +52,12 @@ async fn append_updates_membership() -> Result<()> {
                 ent(1, 1),
                 Entry {
                     log_id: LogId { term: 1, index: 2 },
-                    payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {1,2})),
+                    payload: EntryPayload::Membership(Membership::new_single(btreeset! {1,2})),
                 },
                 ent(1, 3),
                 Entry {
                     log_id: LogId { term: 1, index: 4 },
-                    payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {1,2,3,4})),
+                    payload: EntryPayload::Membership(Membership::new_single(btreeset! {1,2,3,4})),
                 },
                 ent(1, 5),
             ],

--- a/async-raft/tests/client_writes.rs
+++ b/async-raft/tests/client_writes.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::LogId;
 use async_raft::State;
@@ -107,7 +107,7 @@ async fn client_writes() -> Result<()> {
             want,
             Some(0),
             LogId { term: 1, index: want },
-            Some(((5000..5100).into(), 1, MembershipConfig::new_single(btreeset! {0,1,2}))),
+            Some(((5000..5100).into(), 1, Membership::new_single(btreeset! {0,1,2}))),
         )
         .await?;
 

--- a/async-raft/tests/client_writes.rs
+++ b/async-raft/tests/client_writes.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::LogId;
 use async_raft::State;
@@ -107,7 +106,7 @@ async fn client_writes() -> Result<()> {
             want,
             Some(0),
             LogId { term: 1, index: want },
-            Some(((5000..5100).into(), 1, Membership::new_single(btreeset! {0,1,2}))),
+            Some(((5000..5100).into(), 1)),
         )
         .await?;
 

--- a/async-raft/tests/compaction.rs
+++ b/async-raft/tests/compaction.rs
@@ -4,7 +4,6 @@ use anyhow::Result;
 use async_raft::raft::AppendEntriesRequest;
 use async_raft::raft::Entry;
 use async_raft::raft::EntryPayload;
-use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::LogId;
 use async_raft::RaftNetwork;
@@ -76,7 +75,7 @@ async fn compaction() -> Result<()> {
             n_logs,
             Some(0),
             LogId { term: 1, index: n_logs },
-            Some((n_logs.into(), 1, Membership::new_single(btreeset! {0}))),
+            Some((n_logs.into(), 1)),
         )
         .await?;
 
@@ -107,7 +106,7 @@ async fn compaction() -> Result<()> {
         assert_eq!(LogId { term: 1, index: 51 }, logs[0].log_id)
     }
 
-    let expected_snap = Some((snapshot_threshold.into(), 1, Membership::new_single(btreeset! {0})));
+    let expected_snap = Some((snapshot_threshold.into(), 1));
     router
         .assert_storage_state(
             1,

--- a/async-raft/tests/compaction.rs
+++ b/async-raft/tests/compaction.rs
@@ -128,7 +128,7 @@ async fn compaction() -> Result<()> {
                 leader_id: 0,
                 prev_log_id: LogId::new(1, 2),
                 entries: vec![],
-                leader_commit: 0,
+                leader_commit: LogId::new(0, 0),
             })
             .await?;
 

--- a/async-raft/tests/compaction.rs
+++ b/async-raft/tests/compaction.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use async_raft::raft::AppendEntriesRequest;
 use async_raft::raft::Entry;
 use async_raft::raft::EntryPayload;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::LogId;
 use async_raft::RaftNetwork;
@@ -76,7 +76,7 @@ async fn compaction() -> Result<()> {
             n_logs,
             Some(0),
             LogId { term: 1, index: n_logs },
-            Some((n_logs.into(), 1, MembershipConfig::new_single(btreeset! {0}))),
+            Some((n_logs.into(), 1, Membership::new_single(btreeset! {0}))),
         )
         .await?;
 
@@ -107,11 +107,7 @@ async fn compaction() -> Result<()> {
         assert_eq!(LogId { term: 1, index: 51 }, logs[0].log_id)
     }
 
-    let expected_snap = Some((
-        snapshot_threshold.into(),
-        1,
-        MembershipConfig::new_single(btreeset! {0}),
-    ));
+    let expected_snap = Some((snapshot_threshold.into(), 1, Membership::new_single(btreeset! {0})));
     router
         .assert_storage_state(
             1,

--- a/async-raft/tests/conflict_with_empty_entries.rs
+++ b/async-raft/tests/conflict_with_empty_entries.rs
@@ -52,7 +52,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_id: 1,
         prev_log_id: LogId::new(1, 5),
         entries: vec![],
-        leader_commit: 5,
+        leader_commit: LogId::new(1, 5),
     };
 
     let resp = router.send_append_entries(0, rpc).await?;
@@ -81,7 +81,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
                 }),
             },
         ],
-        leader_commit: 5,
+        leader_commit: LogId::new(1, 5),
     };
 
     let resp = router.send_append_entries(0, rpc).await?;
@@ -95,7 +95,7 @@ async fn conflict_with_empty_entries() -> Result<()> {
         leader_id: 1,
         prev_log_id: LogId::new(1, 3),
         entries: vec![],
-        leader_commit: 5,
+        leader_commit: LogId::new(1, 5),
     };
 
     let resp = router.send_append_entries(0, rpc).await?;

--- a/async-raft/tests/elect_compare_last_log.rs
+++ b/async-raft/tests/elect_compare_last_log.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use anyhow::Result;
 use async_raft::raft::Entry;
 use async_raft::raft::EntryPayload;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::storage::HardState;
 use async_raft::Config;
 use async_raft::LogId;
@@ -44,7 +44,7 @@ async fn elect_compare_last_log() -> Result<()> {
 
         sto0.append_to_log(&[&Entry {
             log_id: LogId { term: 2, index: 1 },
-            payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {0,1})),
+            payload: EntryPayload::Membership(Membership::new_single(btreeset! {0,1})),
         }])
         .await?;
     }
@@ -60,7 +60,7 @@ async fn elect_compare_last_log() -> Result<()> {
         sto1.append_to_log(&[
             &Entry {
                 log_id: LogId { term: 1, index: 1 },
-                payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {0,1})),
+                payload: EntryPayload::Membership(Membership::new_single(btreeset! {0,1})),
             },
             &Entry {
                 log_id: LogId { term: 1, index: 2 },

--- a/async-raft/tests/fixtures/mod.rs
+++ b/async-raft/tests/fixtures/mod.rs
@@ -28,7 +28,7 @@ use async_raft::raft::Entry;
 use async_raft::raft::EntryPayload;
 use async_raft::raft::InstallSnapshotRequest;
 use async_raft::raft::InstallSnapshotResponse;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::raft::VoteRequest;
 use async_raft::raft::VoteResponse;
 use async_raft::storage::RaftStorage;
@@ -665,7 +665,7 @@ impl RaftRouter {
         expect_last_log: u64,
         expect_voted_for: Option<u64>,
         expect_sm_last_applied_log: LogId,
-        expect_snapshot: Option<(ValueTest<u64>, u64, MembershipConfig)>,
+        expect_snapshot: Option<(ValueTest<u64>, u64, Membership)>,
     ) -> anyhow::Result<()> {
         let rt = self.routing_table.read().await;
         for (id, (_node, storage)) in rt.iter() {

--- a/async-raft/tests/fixtures/mod.rs
+++ b/async-raft/tests/fixtures/mod.rs
@@ -28,7 +28,6 @@ use async_raft::raft::Entry;
 use async_raft::raft::EntryPayload;
 use async_raft::raft::InstallSnapshotRequest;
 use async_raft::raft::InstallSnapshotResponse;
-use async_raft::raft::Membership;
 use async_raft::raft::VoteRequest;
 use async_raft::raft::VoteResponse;
 use async_raft::storage::RaftStorage;
@@ -665,7 +664,7 @@ impl RaftRouter {
         expect_last_log: u64,
         expect_voted_for: Option<u64>,
         expect_sm_last_applied_log: LogId,
-        expect_snapshot: Option<(ValueTest<u64>, u64, Membership)>,
+        expect_snapshot: Option<(ValueTest<u64>, u64)>,
     ) -> anyhow::Result<()> {
         let rt = self.routing_table.read().await;
         for (id, (_node, storage)) in rt.iter() {
@@ -699,7 +698,7 @@ impl RaftRouter {
                 );
             }
 
-            if let Some((index_test, term, cfg)) = &expect_snapshot {
+            if let Some((index_test, term)) = &expect_snapshot {
                 let snap = storage
                     .get_current_snapshot()
                     .await
@@ -726,12 +725,6 @@ impl RaftRouter {
                     &snap.meta.last_log_id.term, term,
                     "expected node {} to have snapshot with term {}, got {}",
                     id, term, snap.meta.last_log_id.term
-                );
-
-                assert_eq!(
-                    &snap.meta.membership, cfg,
-                    "expected node {} to have membership config {:?}, got {:?}",
-                    id, cfg, snap.meta.membership
                 );
             }
 

--- a/async-raft/tests/initialization.rs
+++ b/async-raft/tests/initialization.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_raft::raft::EntryPayload;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::EffectiveMembership;
 use async_raft::LogId;
@@ -70,7 +70,7 @@ async fn initialization() -> Result<()> {
         assert_eq!(
             Some(EffectiveMembership {
                 log_id: LogId { term: 1, index: 1 },
-                membership: MembershipConfig::new_single(btreeset! {0,1,2})
+                membership: Membership::new_single(btreeset! {0,1,2})
             }),
             sm_mem
         );

--- a/async-raft/tests/members.rs
+++ b/async-raft/tests/members.rs
@@ -115,9 +115,9 @@ async fn members_add_absent_non_voter_blocking() -> Result<()> {
         for node_id in 0..2 {
             let sto = router.get_storage_handle(&node_id).await?;
             let logs = sto.get_log_entries(..).await?;
-            assert_eq!(n_logs, logs[logs.len() - 1].log_id.index);
+            assert_eq!(n_logs, logs[logs.len() - 1].log_id.index, "node: {}", node_id);
             // 0-th log
-            assert_eq!(n_logs + 1, logs.len() as u64);
+            assert_eq!(n_logs + 1, logs.len() as u64, "node: {}", node_id);
         }
     }
 

--- a/async-raft/tests/members_leader_fix_partial.rs
+++ b/async-raft/tests/members_leader_fix_partial.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use async_raft::raft::Entry;
 use async_raft::raft::EntryPayload;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::LogId;
 use async_raft::Raft;
@@ -43,7 +43,7 @@ async fn members_leader_fix_partial() -> Result<()> {
                 term: 1,
                 index: want + 1,
             },
-            payload: EntryPayload::Membership(MembershipConfig::new_multi(vec![btreeset! {0}, btreeset! {0,1,2}])),
+            payload: EntryPayload::Membership(Membership::new_multi(vec![btreeset! {0}, btreeset! {0,1,2}])),
         }])
         .await?;
     }

--- a/async-raft/tests/snapshot_chunk_size.rs
+++ b/async-raft/tests/snapshot_chunk_size.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::LogId;
 use async_raft::SnapshotPolicy;
@@ -59,7 +59,7 @@ async fn snapshot_chunk_size() -> Result<()> {
         router.client_request_many(0, "0", (snapshot_threshold - want) as usize).await;
         want = snapshot_threshold;
 
-        let want_snap = Some((want.into(), 1, MembershipConfig::new_single(btreeset! {0})));
+        let want_snap = Some((want.into(), 1, Membership::new_single(btreeset! {0})));
 
         router.wait_for_log(&btreeset![0], want, None, "send log to trigger snapshot").await?;
         router.wait_for_snapshot(&btreeset![0], LogId { term: 1, index: want }, None, "snapshot").await?;
@@ -71,7 +71,7 @@ async fn snapshot_chunk_size() -> Result<()> {
         router.new_raft_node(1).await;
         router.add_non_voter(0, 1).await.expect("failed to add new node as non-voter");
 
-        let want_snap = Some((want.into(), 1, MembershipConfig::new_single(btreeset! {0})));
+        let want_snap = Some((want.into(), 1, Membership::new_single(btreeset! {0})));
 
         router.wait_for_log(&btreeset![0, 1], want, None, "add non-voter").await?;
         router.wait_for_snapshot(&btreeset![1], LogId { term: 1, index: want }, None, "").await?;

--- a/async-raft/tests/snapshot_chunk_size.rs
+++ b/async-raft/tests/snapshot_chunk_size.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::LogId;
 use async_raft::SnapshotPolicy;
@@ -59,7 +58,7 @@ async fn snapshot_chunk_size() -> Result<()> {
         router.client_request_many(0, "0", (snapshot_threshold - want) as usize).await;
         want = snapshot_threshold;
 
-        let want_snap = Some((want.into(), 1, Membership::new_single(btreeset! {0})));
+        let want_snap = Some((want.into(), 1));
 
         router.wait_for_log(&btreeset![0], want, None, "send log to trigger snapshot").await?;
         router.wait_for_snapshot(&btreeset![0], LogId { term: 1, index: want }, None, "snapshot").await?;
@@ -71,7 +70,7 @@ async fn snapshot_chunk_size() -> Result<()> {
         router.new_raft_node(1).await;
         router.add_non_voter(0, 1).await.expect("failed to add new node as non-voter");
 
-        let want_snap = Some((want.into(), 1, Membership::new_single(btreeset! {0})));
+        let want_snap = Some((want.into(), 1));
 
         router.wait_for_log(&btreeset![0, 1], want, None, "add non-voter").await?;
         router.wait_for_snapshot(&btreeset![1], LogId { term: 1, index: want }, None, "").await?;

--- a/async-raft/tests/snapshot_ge_half_threshold.rs
+++ b/async-raft/tests/snapshot_ge_half_threshold.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::LogId;
 use async_raft::SnapshotPolicy;
@@ -68,13 +67,7 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
 
         router.wait_for_snapshot(&btreeset![0], LogId { term: 1, index: want }, None, "snapshot").await?;
         router
-            .assert_storage_state(
-                1,
-                want,
-                Some(0),
-                LogId { term: 1, index: want },
-                Some((want.into(), 1, Membership::new_single(btreeset! {0}))),
-            )
+            .assert_storage_state(1, want, Some(0), LogId { term: 1, index: want }, Some((want.into(), 1)))
             .await?;
     }
 
@@ -90,7 +83,7 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
         router.add_non_voter(0, 1).await.expect("failed to add new node as non-voter");
 
         router.wait_for_log(&btreeset![0, 1], want, None, "add non-voter").await?;
-        let expected_snap = Some((want.into(), 1, Membership::new_single(btreeset! {0})));
+        let expected_snap = Some((want.into(), 1));
         router.wait_for_snapshot(&btreeset![1], LogId { term: 1, index: want }, None, "").await?;
         router
             .assert_storage_state(

--- a/async-raft/tests/snapshot_ge_half_threshold.rs
+++ b/async-raft/tests/snapshot_ge_half_threshold.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::LogId;
 use async_raft::SnapshotPolicy;
@@ -73,7 +73,7 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
                 want,
                 Some(0),
                 LogId { term: 1, index: want },
-                Some((want.into(), 1, MembershipConfig::new_single(btreeset! {0}))),
+                Some((want.into(), 1, Membership::new_single(btreeset! {0}))),
             )
             .await?;
     }
@@ -90,7 +90,7 @@ async fn snapshot_ge_half_threshold() -> Result<()> {
         router.add_non_voter(0, 1).await.expect("failed to add new node as non-voter");
 
         router.wait_for_log(&btreeset![0, 1], want, None, "add non-voter").await?;
-        let expected_snap = Some((want.into(), 1, MembershipConfig::new_single(btreeset! {0})));
+        let expected_snap = Some((want.into(), 1, Membership::new_single(btreeset! {0})));
         router.wait_for_snapshot(&btreeset![1], LogId { term: 1, index: want }, None, "").await?;
         router
             .assert_storage_state(

--- a/async-raft/tests/snapshot_overrides_membership.rs
+++ b/async-raft/tests/snapshot_overrides_membership.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use async_raft::raft::AppendEntriesRequest;
 use async_raft::raft::Entry;
 use async_raft::raft::EntryPayload;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::LogId;
 use async_raft::RaftNetwork;
@@ -77,7 +77,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 want,
                 Some(0),
                 LogId { term: 1, index: want },
-                Some((want.into(), 1, MembershipConfig::new_single(btreeset! {0}))),
+                Some((want.into(), 1, Membership::new_single(btreeset! {0}))),
             )
             .await?;
     }
@@ -96,7 +96,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
                 prev_log_id: LogId::new(0, 0),
                 entries: vec![Entry {
                     log_id: LogId { term: 1, index: 1 },
-                    payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {2,3})),
+                    payload: EntryPayload::Membership(Membership::new_single(btreeset! {2,3})),
                 }],
                 leader_commit: 0,
             };
@@ -105,7 +105,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
             tracing::info!("--- check that non-voter membership is affected");
             {
                 let m = sto.get_membership_config().await?;
-                assert_eq!(MembershipConfig::new_single(btreeset! {2,3}), m.membership);
+                assert_eq!(Membership::new_single(btreeset! {2,3}), m.membership);
             }
         }
 
@@ -118,7 +118,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
             router.wait_for_log(&btreeset![0, 1], want, timeout(), "add non-voter").await?;
             router.wait_for_snapshot(&btreeset![1], LogId { term: 1, index: want }, timeout(), "").await?;
 
-            let expected_snap = Some((want.into(), 1, MembershipConfig::new_single(btreeset! {0})));
+            let expected_snap = Some((want.into(), 1, Membership::new_single(btreeset! {0})));
 
             router
                 .assert_storage_state(
@@ -132,7 +132,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
 
             let m = sto.get_membership_config().await?;
             assert_eq!(
-                MembershipConfig::new_single(btreeset! {0}),
+                Membership::new_single(btreeset! {0}),
                 m.membership,
                 "membership should be overridden by the snapshot"
             );

--- a/async-raft/tests/snapshot_overrides_membership.rs
+++ b/async-raft/tests/snapshot_overrides_membership.rs
@@ -72,13 +72,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
             .wait_for_snapshot(&btreeset![0], LogId { term: 1, index: want }, timeout(), "snapshot")
             .await?;
         router
-            .assert_storage_state(
-                1,
-                want,
-                Some(0),
-                LogId { term: 1, index: want },
-                Some((want.into(), 1, Membership::new_single(btreeset! {0}))),
-            )
+            .assert_storage_state(1, want, Some(0), LogId { term: 1, index: want }, Some((want.into(), 1)))
             .await?;
     }
 
@@ -118,7 +112,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
             router.wait_for_log(&btreeset![0, 1], want, timeout(), "add non-voter").await?;
             router.wait_for_snapshot(&btreeset![1], LogId { term: 1, index: want }, timeout(), "").await?;
 
-            let expected_snap = Some((want.into(), 1, Membership::new_single(btreeset! {0})));
+            let expected_snap = Some((want.into(), 1));
 
             router
                 .assert_storage_state(

--- a/async-raft/tests/snapshot_overrides_membership.rs
+++ b/async-raft/tests/snapshot_overrides_membership.rs
@@ -98,7 +98,7 @@ async fn snapshot_overrides_membership() -> Result<()> {
                     log_id: LogId { term: 1, index: 1 },
                     payload: EntryPayload::Membership(Membership::new_single(btreeset! {2,3})),
                 }],
-                leader_commit: 0,
+                leader_commit: LogId::new(0, 0),
             };
             router.send_append_entries(1, req).await?;
 

--- a/async-raft/tests/snapshot_uses_prev_snap_membership.rs
+++ b/async-raft/tests/snapshot_uses_prev_snap_membership.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::LogId;
 use async_raft::MessageSummary;
@@ -87,11 +87,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
             assert_eq!(2, logs.len(), "only one applied log is kept");
         }
         let m = sto0.get_membership_config().await?;
-        assert_eq!(
-            MembershipConfig::new_single(btreeset! {0,1}),
-            m.membership,
-            "membership "
-        );
+        assert_eq!(Membership::new_single(btreeset! {0,1}), m.membership, "membership ");
 
         // TODO(xp): this assertion fails because when change-membership, a append-entries request does not update
         //           voted_for and does not call save_hard_state.
@@ -127,11 +123,7 @@ async fn snapshot_uses_prev_snap_membership() -> Result<()> {
             assert_eq!(2, logs.len(), "only one applied log");
         }
         let m = sto0.get_membership_config().await?;
-        assert_eq!(
-            MembershipConfig::new_single(btreeset! {0,1}),
-            m.membership,
-            "membership "
-        );
+        assert_eq!(Membership::new_single(btreeset! {0,1}), m.membership, "membership ");
     }
 
     Ok(())

--- a/async-raft/tests/state_machien_apply_membership.rs
+++ b/async-raft/tests/state_machien_apply_membership.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::Result;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::Config;
 use async_raft::EffectiveMembership;
 use async_raft::LogId;
@@ -53,7 +53,7 @@ async fn state_machine_apply_membership() -> Result<()> {
         assert_eq!(
             Some(EffectiveMembership {
                 log_id: LogId { term: 1, index: 1 },
-                membership: MembershipConfig::new_single(btreeset! {0})
+                membership: Membership::new_single(btreeset! {0})
             }),
             sto.last_applied_state().await?.1
         );
@@ -95,7 +95,7 @@ async fn state_machine_apply_membership() -> Result<()> {
         assert_eq!(
             Some(EffectiveMembership {
                 log_id: LogId { term: 1, index: 3 },
-                membership: MembershipConfig::new_single(btreeset! {0,1,2})
+                membership: Membership::new_single(btreeset! {0,1,2})
             }),
             last_membership
         );

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -392,7 +392,6 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn do_log_compaction(&self) -> Result<Snapshot<Self::SnapshotData>, StorageError> {
         let (data, last_applied_log);
-        let membership_config;
 
         {
             // Serialize the data of the state machine.
@@ -401,8 +400,6 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
                 .map_err(|e| StorageIOError::new(ErrorSubject::StateMachine, ErrorVerb::Read, e.into()))?;
 
             last_applied_log = sm.last_applied_log;
-            membership_config =
-                sm.last_membership.clone().map(|x| x.membership).unwrap_or_else(|| Membership::new_initial(self.id));
         }
 
         let snapshot_size = data.len();
@@ -422,7 +419,6 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
             meta = SnapshotMeta {
                 last_log_id: last_applied_log,
                 snapshot_id,
-                membership: membership_config.clone(),
             };
 
             let snapshot = MemStoreSnapshot {

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -17,7 +17,7 @@ use std::sync::Mutex;
 use async_raft::async_trait::async_trait;
 use async_raft::raft::Entry;
 use async_raft::raft::EntryPayload;
-use async_raft::raft::MembershipConfig;
+use async_raft::raft::Membership;
 use async_raft::storage::HardState;
 use async_raft::storage::InitialState;
 use async_raft::storage::Snapshot;
@@ -207,7 +207,7 @@ impl MemStore {
             Some(x) => x,
             None => EffectiveMembership {
                 log_id: LogId { term: 0, index: 0 },
-                membership: MembershipConfig::new_initial(self.id),
+                membership: Membership::new_initial(self.id),
             },
         })
     }
@@ -400,11 +400,8 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
                 .map_err(|e| StorageIOError::new(ErrorSubject::StateMachine, ErrorVerb::Read, e.into()))?;
 
             last_applied_log = sm.last_applied_log;
-            membership_config = sm
-                .last_membership
-                .clone()
-                .map(|x| x.membership)
-                .unwrap_or_else(|| MembershipConfig::new_initial(self.id));
+            membership_config =
+                sm.last_membership.clone().map(|x| x.membership).unwrap_or_else(|| Membership::new_initial(self.id));
         }
 
         let snapshot_size = data.len();

--- a/memstore/src/lib.rs
+++ b/memstore/src/lib.rs
@@ -305,11 +305,12 @@ impl RaftStorage<ClientRequest, ClientResponse> for MemStore {
 
     async fn first_known_log_id(&self) -> Result<LogId, StorageError> {
         let first = self.first_id_in_log().await?;
+        let (last_applied, _) = self.last_applied_state().await?;
+
         if let Some(x) = first {
-            return Ok(x);
+            return Ok(std::cmp::min(x, last_applied));
         }
 
-        let (last_applied, _) = self.last_applied_state().await?;
         Ok(last_applied)
     }
 

--- a/memstore/src/test.rs
+++ b/memstore/src/test.rs
@@ -114,7 +114,7 @@ where
 
         let membership = store.get_membership_config().await?;
 
-        assert_eq!(MembershipConfig::new_single(btreeset! {NODE_ID}), membership.membership,);
+        assert_eq!(Membership::new_single(btreeset! {NODE_ID}), membership.membership,);
 
         Ok(())
     }
@@ -132,14 +132,14 @@ where
                     },
                     &Entry {
                         log_id: LogId { term: 1, index: 2 },
-                        payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {3,4,5})),
+                        payload: EntryPayload::Membership(Membership::new_single(btreeset! {3,4,5})),
                     },
                 ])
                 .await?;
 
             let mem = store.get_membership_config().await?;
 
-            assert_eq!(MembershipConfig::new_single(btreeset! {3,4,5}), mem.membership,);
+            assert_eq!(Membership::new_single(btreeset! {3,4,5}), mem.membership,);
         }
 
         tracing::info!("--- membership presents in log, but smaller than last_applied, read from state machine");
@@ -147,13 +147,13 @@ where
             store
                 .append_to_log(&[&Entry {
                     log_id: (1, 1).into(),
-                    payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {1,2,3})),
+                    payload: EntryPayload::Membership(Membership::new_single(btreeset! {1,2,3})),
                 }])
                 .await?;
 
             let mem = store.get_membership_config().await?;
 
-            assert_eq!(MembershipConfig::new_single(btreeset! {3, 4, 5}), mem.membership,);
+            assert_eq!(Membership::new_single(btreeset! {3, 4, 5}), mem.membership,);
         }
 
         tracing::info!("--- membership presents in log and > sm.last_applied, read from log");
@@ -161,13 +161,13 @@ where
             store
                 .append_to_log(&[&Entry {
                     log_id: LogId { term: 1, index: 3 },
-                    payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {1,2,3})),
+                    payload: EntryPayload::Membership(Membership::new_single(btreeset! {1,2,3})),
                 }])
                 .await?;
 
             let mem = store.get_membership_config().await?;
 
-            assert_eq!(MembershipConfig::new_single(btreeset! {1,2,3},), mem.membership,);
+            assert_eq!(Membership::new_single(btreeset! {1,2,3},), mem.membership,);
         }
 
         Ok(())
@@ -195,7 +195,7 @@ where
         );
 
         assert_eq!(
-            MembershipConfig::new_single(btreeset! {NODE_ID}),
+            Membership::new_single(btreeset! {NODE_ID}),
             initial.last_membership.membership,
         );
 
@@ -265,7 +265,7 @@ where
                     },
                     &Entry {
                         log_id: LogId { term: 1, index: 2 },
-                        payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {3,4,5})),
+                        payload: EntryPayload::Membership(Membership::new_single(btreeset! {3,4,5})),
                     },
                 ])
                 .await?;
@@ -273,7 +273,7 @@ where
             let initial = store.get_initial_state().await?;
 
             assert_eq!(
-                MembershipConfig::new_single(btreeset! {3,4,5}),
+                Membership::new_single(btreeset! {3,4,5}),
                 initial.last_membership.membership,
             );
         }
@@ -283,14 +283,14 @@ where
             store
                 .append_to_log(&[&Entry {
                     log_id: (1, 1).into(),
-                    payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {1,2,3})),
+                    payload: EntryPayload::Membership(Membership::new_single(btreeset! {1,2,3})),
                 }])
                 .await?;
 
             let initial = store.get_initial_state().await?;
 
             assert_eq!(
-                MembershipConfig::new_single(btreeset! {3,4,5}),
+                Membership::new_single(btreeset! {3,4,5}),
                 initial.last_membership.membership,
             );
         }
@@ -300,14 +300,14 @@ where
             store
                 .append_to_log(&[&Entry {
                     log_id: LogId { term: 1, index: 3 },
-                    payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {1,2,3})),
+                    payload: EntryPayload::Membership(Membership::new_single(btreeset! {1,2,3})),
                 }])
                 .await?;
 
             let initial = store.get_initial_state().await?;
 
             assert_eq!(
-                MembershipConfig::new_single(btreeset! {1,2,3}),
+                Membership::new_single(btreeset! {1,2,3}),
                 initial.last_membership.membership,
             );
         }
@@ -611,7 +611,7 @@ where
             store
                 .apply_to_state_machine(&[&Entry {
                     log_id: LogId { term: 1, index: 3 },
-                    payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {1,2})),
+                    payload: EntryPayload::Membership(Membership::new_single(btreeset! {1,2})),
                 }])
                 .await?;
 
@@ -620,7 +620,7 @@ where
             assert_eq!(
                 Some(EffectiveMembership {
                     log_id: LogId { term: 1, index: 3 },
-                    membership: MembershipConfig::new_single(btreeset! {1,2})
+                    membership: Membership::new_single(btreeset! {1,2})
                 }),
                 membership
             );
@@ -640,7 +640,7 @@ where
             assert_eq!(
                 Some(EffectiveMembership {
                     log_id: LogId { term: 1, index: 3 },
-                    membership: MembershipConfig::new_single(btreeset! {1,2})
+                    membership: Membership::new_single(btreeset! {1,2})
                 }),
                 membership
             );
@@ -908,7 +908,7 @@ where
                     },
                     &Entry {
                         log_id: LogId { term: 1, index: 3 },
-                        payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {1,2,3})),
+                        payload: EntryPayload::Membership(Membership::new_single(btreeset! {1,2,3})),
                     },
                 ])
                 .await?;
@@ -920,7 +920,7 @@ where
                     },
                     &Entry {
                         log_id: LogId { term: 2, index: 2 },
-                        payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {3,4,5})),
+                        payload: EntryPayload::Membership(Membership::new_single(btreeset! {3,4,5})),
                     },
                 ])
                 .await?;
@@ -958,7 +958,7 @@ where
                     },
                     &Entry {
                         log_id: LogId { term: 1, index: 3 },
-                        payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {1,2,3})),
+                        payload: EntryPayload::Membership(Membership::new_single(btreeset! {1,2,3})),
                     },
                 ])
                 .await?;
@@ -971,7 +971,7 @@ where
                     },
                     &Entry {
                         log_id: LogId { term: 2, index: 2 },
-                        payload: EntryPayload::Membership(MembershipConfig::new_single(btreeset! {3,4,5})),
+                        payload: EntryPayload::Membership(Membership::new_single(btreeset! {3,4,5})),
                     },
                 ])
                 .await?;


### PR DESCRIPTION

## Changelog

##### change: remove unused field SnapshotMeta::membership

##### change: track committed log id instead of just a commit index

##### refactor: adjust logs

##### fix: first_known_log_id() should returns the min one in log or in state machine

##### refactor: explain membership

##### change: rename MembershipConfig to Membership

---


- Bug Fix

- Improvement