### PR TITLE
Feature: add absolute timestamp `RaftMetrics::last_quorum_acked`

### DIFF
--- a/openraft/src/core/raft_core.rs
+++ b/openraft/src/core/raft_core.rs
@@ -60,6 +60,7 @@ use crate::metrics::RaftDataMetrics;
 use crate::metrics::RaftMetrics;
 use crate::metrics::RaftServerMetrics;
 use crate::metrics::ReplicationMetrics;
+use crate::metrics::SerdeInstant;
 use crate::network::v2::RaftNetworkV2;
 use crate::network::RPCOption;
 use crate::network::RPCTypes;
@@ -553,6 +554,7 @@ where
         let membership_config = st.membership_state.effective().stored_membership().clone();
         let current_leader = self.current_leader();
 
+        #[allow(deprecated)]
         let m = RaftMetrics {
             running_state: Ok(()),
             id: self.id,
@@ -569,6 +571,7 @@ where
             state: st.server_state,
             current_leader,
             millis_since_quorum_ack,
+            last_quorum_acked: last_quorum_acked.map(SerdeInstant::new),
             membership_config: membership_config.clone(),
             heartbeat: heartbeat.clone(),
 
@@ -576,12 +579,14 @@ where
             replication: replication.clone(),
         };
 
+        #[allow(deprecated)]
         let data_metrics = RaftDataMetrics {
             last_log: st.last_log_id().copied(),
             last_applied: st.io_applied().copied(),
             snapshot: st.io_snapshot_last_log_id().copied(),
             purged: st.io_purged().copied(),
             millis_since_quorum_ack,
+            last_quorum_acked: last_quorum_acked.map(SerdeInstant::new),
             replication,
             heartbeat,
         };

--- a/openraft/src/error.rs
+++ b/openraft/src/error.rs
@@ -232,8 +232,6 @@ where C: RaftTypeConfig
     #[error(transparent)]
     Closed(#[from] ReplicationClosed),
 
-    // TODO(xp): two sub type: StorageError / TransportError
-    // TODO(xp): a sub error for just append_entries()
     #[error(transparent)]
     StorageError(#[from] StorageError<C>),
 

--- a/openraft/src/metrics/mod.rs
+++ b/openraft/src/metrics/mod.rs
@@ -32,6 +32,7 @@ mod raft_metrics;
 mod wait;
 
 mod metric_display;
+mod serde_instant;
 mod wait_condition;
 #[cfg(test)]
 mod wait_test;
@@ -42,6 +43,7 @@ pub use metric::Metric;
 pub use raft_metrics::RaftDataMetrics;
 pub use raft_metrics::RaftMetrics;
 pub use raft_metrics::RaftServerMetrics;
+pub use serde_instant::SerdeInstant;
 pub use wait::Wait;
 pub use wait::WaitError;
 pub(crate) use wait_condition::Condition;

--- a/openraft/src/metrics/serde_instant.rs
+++ b/openraft/src/metrics/serde_instant.rs
@@ -1,0 +1,201 @@
+use std::fmt;
+use std::fmt::Formatter;
+use std::ops::Deref;
+
+use crate::display_ext::DisplayInstantExt;
+use crate::Instant;
+
+/// A wrapper for [`Instant`] that supports serialization and deserialization.
+///
+/// This struct serializes an `Instant` into a string formatted as "%Y-%m-%dT%H:%M:%S%.9f%z", e.g.,
+/// "2024-07-24T04:07:32.567025000+0000".
+///
+/// Note: Serialization and deserialization are not perfectly accurate and can be indeterministic,
+/// resulting in minor variations each time. These deviations(could be smaller or greater) are
+/// typically less than a microsecond (10^-6 seconds).
+#[derive(Debug, Clone, Copy)]
+#[derive(PartialEq, Eq)]
+#[derive(PartialOrd, Ord)]
+pub struct SerdeInstant<I>
+where I: Instant
+{
+    inner: I,
+}
+
+impl<I> Deref for SerdeInstant<I>
+where I: Instant
+{
+    type Target = I;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<I> From<I> for SerdeInstant<I>
+where I: Instant
+{
+    fn from(inner: I) -> Self {
+        Self { inner }
+    }
+}
+
+impl<I> fmt::Display for SerdeInstant<I>
+where I: Instant
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.inner.display().fmt(f)
+    }
+}
+
+impl<I> SerdeInstant<I>
+where I: Instant
+{
+    pub fn new(inner: I) -> Self {
+        Self { inner }
+    }
+
+    pub fn into_inner(self) -> I {
+        self.inner
+    }
+}
+
+#[cfg(feature = "serde")]
+mod serde_impl {
+    use std::fmt;
+    use std::marker::PhantomData;
+    use std::time::SystemTime;
+
+    use chrono::DateTime;
+    use chrono::Utc;
+    use serde::de;
+    use serde::de::Visitor;
+    use serde::Deserialize;
+    use serde::Deserializer;
+    use serde::Serialize;
+    use serde::Serializer;
+
+    use super::SerdeInstant;
+    use crate::Instant;
+
+    impl<I> SerdeInstant<I>
+    where I: Instant
+    {
+        const SERDE_FMT: &'static str = "%Y-%m-%dT%H:%M:%S%.9f%z";
+    }
+
+    impl<I> Serialize for SerdeInstant<I>
+    where I: Instant
+    {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer {
+            // Convert Instant to SystemTime
+            let system_time = {
+                let sys_now = SystemTime::now();
+                let now = I::now();
+
+                if now >= self.inner {
+                    let d = now - self.inner;
+                    sys_now - d
+                } else {
+                    let d = self.inner - now;
+                    sys_now + d
+                }
+            };
+
+            // Convert `SystemTime` to `DateTime<Utc>`
+            let datetime: DateTime<Utc> = system_time.into();
+
+            // Format the datetime to the desired string format
+            let datetime_str = datetime.format(Self::SERDE_FMT).to_string();
+
+            // Serialize the datetime string
+            serializer.serialize_str(&datetime_str)
+        }
+    }
+
+    impl<'de, I> Deserialize<'de> for SerdeInstant<I>
+    where I: Instant
+    {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: Deserializer<'de> {
+            struct InstantVisitor<II: Instant>(PhantomData<II>);
+
+            impl<'de, II: Instant> Visitor<'de> for InstantVisitor<II> {
+                type Value = SerdeInstant<II>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                    // formatter.write_str("a string representing a datetime in the format %Y-%m-%dT%H:%M:%S%.6f%z")
+                    write!(
+                        formatter,
+                        "a string representing a datetime in the format {}",
+                        SerdeInstant::<II>::SERDE_FMT
+                    )
+                }
+
+                fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+                where E: de::Error {
+                    // Parse the datetime string back to `DateTime<Utc>`
+                    // 2024-07-19T09:30:46.635735000
+                    let datetime =
+                        DateTime::parse_from_str(value, SerdeInstant::<II>::SERDE_FMT).map_err(de::Error::custom)?;
+
+                    // Convert `DateTime<Utc>` to `SystemTime`
+                    let system_time: SystemTime = datetime.with_timezone(&Utc).into();
+
+                    // Calculate the `Instant` from the current time
+                    let sys_now = SystemTime::now();
+                    let now = II::now();
+                    let instant = if system_time > sys_now {
+                        now + (system_time.duration_since(sys_now).unwrap())
+                    } else {
+                        now - (sys_now.duration_since(system_time).unwrap())
+                    };
+                    Ok(SerdeInstant { inner: instant })
+                }
+            }
+
+            deserializer.deserialize_str(InstantVisitor::<I>(Default::default()))
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::time::Duration;
+
+        use super::SerdeInstant;
+        use crate::engine::testing::UTConfig;
+        use crate::type_config::alias::InstantOf;
+        use crate::type_config::TypeConfigExt;
+
+        #[test]
+        fn test_serde_instant() {
+            let now = UTConfig::<()>::now();
+            let serde_instant = SerdeInstant::new(now);
+            let json = serde_json::to_string(&serde_instant).unwrap();
+            let deserialized: SerdeInstant<InstantOf<UTConfig>> = serde_json::from_str(&json).unwrap();
+
+            println!("Now: {:?}", now);
+            println!("Des: {:?}", *deserialized);
+            // Convert Instant to SerdeInstant is inaccurate.
+            if now > *deserialized {
+                assert!((now - *deserialized) < Duration::from_millis(500));
+            } else {
+                assert!((*deserialized - now) < Duration::from_millis(500));
+            }
+
+            // Test serialization format
+
+            let timestamp = r#""2024-07-24T04:07:32.567025000+0000""#;
+            let deserialized: SerdeInstant<InstantOf<UTConfig>> = serde_json::from_str(timestamp).unwrap();
+            let serialized = serde_json::to_string(&deserialized).unwrap();
+
+            assert_eq!(
+                timestamp[0..24],
+                serialized[0..24],
+                "compare upto milli seconds: {}",
+                &timestamp[0..24]
+            );
+        }
+    }
+}

--- a/openraft/src/metrics/wait_test.rs
+++ b/openraft/src/metrics/wait_test.rs
@@ -249,6 +249,7 @@ pub(crate) type InitResult<C> = (RaftMetrics<C>, Wait<C>, WatchSenderOf<C, RaftM
 /// Returns init metrics, Wait, and the tx to send an updated metrics.
 fn init_wait_test<C>() -> InitResult<C>
 where C: RaftTypeConfig {
+    #[allow(deprecated)]
     let init = RaftMetrics {
         running_state: Ok(()),
         id: NodeIdOf::<C>::default(),
@@ -261,6 +262,7 @@ where C: RaftTypeConfig {
 
         current_leader: None,
         millis_since_quorum_ack: None,
+        last_quorum_acked: None,
         membership_config: Arc::new(StoredMembership::new(None, Membership::new(vec![btreeset! {}], None))),
         heartbeat: None,
 

--- a/scripts/check.kdl
+++ b/scripts/check.kdl
@@ -21,17 +21,14 @@ layout {
             pane {
                 command "cargo"
                 args "test" "--lib"
-                close_on_exit true
             }
             pane {
                 command "cargo"
                 args "test" "--test" "*"
-                close_on_exit true
             }
             pane {
                 command "cargo"
                 args "clippy" "--no-deps" "--all-targets" "--" "-D" "warnings"
-                close_on_exit true
             }
         }
         // status-bar


### PR DESCRIPTION
`RaftMetrics::last_quorum_acked` is the absolute timestamp of the most recent time point that is accepted by a quorum via `AppendEntries` RPC. This field is a wrapped `Instant` type: `SerdeInstant` which support serde for `Instant`. This field is added as a replacement of `millis_since_quorum_ack`, which is a relative time.

`SerdeInstant` serialize `Instant` into a string formatted as "%Y-%m-%dT%H:%M:%S%.9f%z", e.g., "2024-07-24T04:07:32.567025000+0000".

Note: Serialization and deserialization are not perfectly accurate and can be indeterministic, resulting in minor variations each time. These deviations(could be smaller or greater) are typically less than a microsecond (10^-6 seconds).

<!--
Thank you for taking the time to open a pull request!
Please review the checklist below and perform each of
the applicable tasks. ❤️!

A great pull-request has only one commit:
Before publish a PR(already published PR should not be rebased), rebase your branch onto `main` and squash them into one commit with:
`git update-ref refs/heads/my_branch $(echo "commit_message" | git commit-tree my_branch^{tree} -p main)`

Replace `my_branch` and `commit_message` with actual values.
-->




**Checklist**

- [ ] Updated guide with pertinent info (may not always apply). <!-- Mark complete if nothing to do. -->
- [ ] Squash down commits to one or two logical commits which clearly describe the work you've done.
- [ ] Unittest is a friend:)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced metrics handling in the Raft protocol with improved serialization for time-related metrics.
	- Introduced a new field, `last_quorum_acked`, to track leader acknowledgment timing in `RaftMetrics` and `RaftDataMetrics`.
	- Added a new module for handling serialization of time instances.
	
- **Bug Fixes**
	- Improved error handling structure by removing deprecated enhancement comments.

- **Tests**
	- Expanded test coverage for leader acknowledgment timing in single and multi-node scenarios.
  
- **Chores**
	- Modified KDL script to ensure command output panes remain open after execution for better debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->